### PR TITLE
Upgraded to Vert.X 3.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Eclipse
+.classpath
+.project
+.settings/
+ 
+# Intellij
+.idea/
+*.iml
+*.iws
+ 
+# Mac
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+ 
+# Maven
+log/
+target/
+
+# Vert.x
+.vertx
+
+# Misc
+*.swp
+*.bak
+.svn
+.vagrant
+.data
+.orig
+_tmp
+console.json
+console.log
+console-*.log
+console-*.json
+dms-*/log
+esi

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.etourdot</groupId>
     <artifactId>vertx-mod-xml</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>xml-mod</name>
 
@@ -57,7 +57,7 @@
 
         <!-- dependency versions -->
         <version.junit>4.11</version.junit>
-        <version.vertx>2.1</version.vertx>
+        <version.vertx>3.4.1</version.vertx>
         <version.testtools>2.0.3-final</version.testtools>
         <version.saxonHE>9.5.1-6</version.saxonHE>
     </properties>
@@ -92,20 +92,7 @@
             <version>${version.vertx}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-platform</artifactId>
-            <version>${version.vertx}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-hazelcast</artifactId>
-            <version>${version.vertx}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- other dependencies -->
+       <!-- other dependencies -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -120,9 +107,8 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>testtools</artifactId>
-            <version>${version.testtools}</version>
-            <scope>test</scope>
+            <artifactId>vertx-unit</artifactId>
+            <version>${version.vertx}</version>
         </dependency>
     </dependencies>
 
@@ -214,8 +200,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                <source>1.8</source>
+                <target>1.8</target>
+                <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
             <plugin>
@@ -325,7 +312,6 @@
                 <configuration>
                     <disableXmlReport>true</disableXmlReport>
                     <argLine>-Xss2048k</argLine>
-                    <verbose>true</verbose>
                     <forkCount>0</forkCount>
                     <!--includes>
                       <include>**unit/*Test*.java</include>
@@ -344,11 +330,11 @@
                         </property>
                     </systemPropertyVariables>
                     <argLine>-Xss2048k -XX:MaxPermSize=128m</argLine>
-                    <verbose>true</verbose>
+                    <!-- <verbose>true</verbose> -->
                     <includes>
                         <include>**/integration/**</include>
                     </includes>
-                    <useSystemClassloader>false</useSystemClassloader>
+                    <!-- <useSystemClassloader>false</useSystemClassloader> -->
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <maven.clean.plugin.version>2.5</maven.clean.plugin.version>
         <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
         <maven.jgitflow.plugin.version>1.0-m4.3</maven.jgitflow.plugin.version>
-        <maven.vertx.plugin.version>2.0.8-final</maven.vertx.plugin.version>
 
         <!-- dependency versions -->
         <version.junit>4.11</version.junit>
@@ -162,38 +161,6 @@
             </extension>
         </extensions>
         <plugins>
-            <plugin>
-                <groupId>io.vertx</groupId>
-                <artifactId>vertx-maven-plugin</artifactId>
-                <version>${maven.vertx.plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>io.vertx</groupId>
-                        <artifactId>vertx-platform</artifactId>
-                        <version>${version.vertx}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>io.vertx</groupId>
-                        <artifactId>vertx-core</artifactId>
-                        <version>${version.vertx}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>io.vertx</groupId>
-                        <artifactId>vertx-hazelcast</artifactId>
-                        <version>${version.vertx}</version>
-                    </dependency>
-                </dependencies>
-
-                <executions>
-                    <execution>
-                        <id>PullInDeps</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>pullInDeps</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/etourdot/vertx/mods/XmlDefaultHandler.java
+++ b/src/main/java/org/etourdot/vertx/mods/XmlDefaultHandler.java
@@ -1,13 +1,14 @@
 package org.etourdot.vertx.mods;
 
-import org.vertx.java.core.Handler;
-import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.core.json.JsonObject;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
 
 /**
  * Created by Emmanuel TOURDOT on 01/09/2014.
  */
 abstract class XmlDefaultHandler implements Handler<Message<?>> {
+
     public abstract void handle(Message<?> message);
 
     void sendOK(Message<JsonObject> message) {
@@ -22,7 +23,7 @@ abstract class XmlDefaultHandler implements Handler<Message<?>> {
         if (json == null) {
             json = new JsonObject();
         }
-        json.putString("status", status);
+        json.put("status", status);
         message.reply(json);
     }
 
@@ -35,7 +36,7 @@ abstract class XmlDefaultHandler implements Handler<Message<?>> {
     }
 
     void sendError(Message<JsonObject> message, String error, Exception e) {
-        JsonObject json = new JsonObject().putString("status", "error").putString("message", error);
+        JsonObject json = new JsonObject().put("status", "error").put("message", error);
         message.reply(json);
     }
 

--- a/src/main/java/org/etourdot/vertx/mods/XmlQueryHandler.java
+++ b/src/main/java/org/etourdot/vertx/mods/XmlQueryHandler.java
@@ -22,31 +22,21 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
-
-import net.sf.saxon.s9api.Processor;
-import net.sf.saxon.s9api.QName;
-import net.sf.saxon.s9api.SaxonApiException;
-import net.sf.saxon.s9api.Serializer;
-import net.sf.saxon.s9api.XQueryCompiler;
-import net.sf.saxon.s9api.XQueryEvaluator;
-import net.sf.saxon.s9api.XQueryExecutable;
-import net.sf.saxon.s9api.XdmAtomicValue;
-
-import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.core.json.JsonArray;
-import org.vertx.java.core.json.JsonObject;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import net.sf.saxon.s9api.*;
 import org.xml.sax.InputSource;
 
+import javax.xml.transform.Source;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.stream.StreamSource;
 
 /**
  * XML Module<p> Please see the busmods manual for a full description<p>
@@ -71,7 +61,7 @@ public class XmlQueryHandler extends XmlDefaultHandler {
         final String query = messageBody.getString(QUERY);
         final String xml = messageBody.getString(XML);
         final String url_xml = messageBody.getString(URL_XML);
-        final JsonArray params = messageBody.getArray(PARAMS);
+        final JsonArray params = messageBody.getJsonArray(PARAMS);
 
         if (Strings.isNullOrEmpty(xml) && Strings.isNullOrEmpty(url_xml)) {
             sendError(message, "xml ou url_xml must be specified");
@@ -110,7 +100,7 @@ public class XmlQueryHandler extends XmlDefaultHandler {
             if (params != null) {
                 for (Object param : params) {
                     final JsonObject object = (JsonObject) param;
-                    for (String fieldName : object.getFieldNames()) {
+                    for (String fieldName : object.fieldNames()) {
                         xQueryEvaluator.setExternalVariable(new QName(fieldName),
                                 new XdmAtomicValue(object.getString(fieldName)));
                     }
@@ -118,7 +108,7 @@ public class XmlQueryHandler extends XmlDefaultHandler {
             }
             xQueryEvaluator.run();
             JsonObject outputObject = new JsonObject();
-            outputObject.putString("output", writer.toString());
+            outputObject.put("output", writer.toString());
             sendOK(message, outputObject);
         } catch (SaxonApiException | UnsupportedEncodingException | ExecutionException e) {
             sendError(message, e.getMessage());

--- a/src/main/java/org/etourdot/vertx/mods/XmlTransformHandler.java
+++ b/src/main/java/org/etourdot/vertx/mods/XmlTransformHandler.java
@@ -23,32 +23,21 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
-
-import net.sf.saxon.s9api.Processor;
-import net.sf.saxon.s9api.QName;
-import net.sf.saxon.s9api.SaxonApiException;
-import net.sf.saxon.s9api.Serializer;
-import net.sf.saxon.s9api.XdmAtomicValue;
-import net.sf.saxon.s9api.XdmNode;
-import net.sf.saxon.s9api.XsltCompiler;
-import net.sf.saxon.s9api.XsltExecutable;
-import net.sf.saxon.s9api.XsltTransformer;
-
-import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.core.json.JsonArray;
-import org.vertx.java.core.json.JsonObject;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import net.sf.saxon.s9api.*;
 import org.xml.sax.InputSource;
 
+import javax.xml.transform.Source;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.stream.StreamSource;
 
 /**
  * XML Module<p> Please see the busmods manual for a full description<p> entrée: { "xsl": source
@@ -77,7 +66,7 @@ public class XmlTransformHandler extends XmlDefaultHandler {
         final String url_xsl = messageBody.getString(URL_XSL);
         final String xml = messageBody.getString(XML);
         final String url_xml = messageBody.getString(URL_XML);
-        final JsonArray params = messageBody.getArray(PARAMS);
+        final JsonArray params = messageBody.getJsonArray(PARAMS);
 
         if (Strings.isNullOrEmpty(xml) && Strings.isNullOrEmpty(url_xml)) {
             sendError(message, "xml ou url_xml must be specified");
@@ -128,14 +117,14 @@ public class XmlTransformHandler extends XmlDefaultHandler {
             if (params != null) {
                 for (Object param : params) {
                     final JsonObject object = (JsonObject) param;
-                    for (String fieldName : object.getFieldNames()) {
+                    for (String fieldName : object.fieldNames()) {
                         xsltTransformer.setParameter(new QName(fieldName), new XdmAtomicValue(object.getString(fieldName)));
                     }
                 }
             }
             xsltTransformer.transform();
             JsonObject outputObject = new JsonObject();
-            outputObject.putString("output", writer.toString());
+            outputObject.put("output", writer.toString());
             sendOK(message, outputObject);
         } catch (SaxonApiException | UnsupportedEncodingException | ExecutionException e) {
             sendError(message, e.getMessage());

--- a/src/main/java/org/etourdot/vertx/mods/XmlValidationHandler.java
+++ b/src/main/java/org/etourdot/vertx/mods/XmlValidationHandler.java
@@ -17,21 +17,17 @@
 package org.etourdot.vertx.mods;
 
 import com.google.common.base.Strings;
-
-
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
 import net.sf.saxon.s9api.Processor;
-
-import org.vertx.java.core.buffer.Buffer;
-import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.core.json.JsonObject;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 
-import java.io.ByteArrayInputStream;
-import java.io.UnsupportedEncodingException;
-
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
 
 /**
  * XML Module<p> Please see the busmods manual for a full description<p>

--- a/src/main/java/org/etourdot/vertx/mods/XmlWorker.java
+++ b/src/main/java/org/etourdot/vertx/mods/XmlWorker.java
@@ -16,15 +16,15 @@
 
 package org.etourdot.vertx.mods;
 
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.eventbus.EventBus;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.s9api.Processor;
-
-import org.vertx.java.busmods.BusModBase;
 
 /**
  * XML Module<p> Please see the busmods manual for a full description<p>
  */
-public class XmlWorker extends BusModBase {
+public class XmlWorker extends AbstractVerticle {
 
     public final static String VALIDATION_ADDRESS = "xmlworker.validation";
     public final static String TRANSFORM_ADDRESS = "xmlworker.transform";
@@ -35,14 +35,14 @@ public class XmlWorker extends BusModBase {
 
     @Override
     public void start() {
-        super.start();
 
         Configuration configuration = new Configuration();
         processor = new Processor(configuration);
-        eb.registerHandler(VALIDATION_ADDRESS, new XmlValidationHandler(processor));
-        eb.registerHandler(TRANSFORM_ADDRESS, new XmlTransformHandler(processor));
-        eb.registerHandler(QUERY_ADDRESS, new XmlQueryHandler(processor));
-        eb.registerHandler(XPATH_ADDRESS, new XmlXPathHandler(processor));
+        EventBus eb = vertx.eventBus();
+        eb.consumer(VALIDATION_ADDRESS, new XmlValidationHandler(processor)::handle);
+        eb.consumer(TRANSFORM_ADDRESS, new XmlTransformHandler(processor)::handle);
+        eb.consumer(QUERY_ADDRESS, new XmlQueryHandler(processor)::handle);
+        eb.consumer(XPATH_ADDRESS, new XmlXPathHandler(processor)::handle);
     }
 
     @Override

--- a/src/main/java/org/etourdot/vertx/mods/XmlXPathHandler.java
+++ b/src/main/java/org/etourdot/vertx/mods/XmlXPathHandler.java
@@ -22,30 +22,20 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
-
-import net.sf.saxon.s9api.Processor;
-import net.sf.saxon.s9api.SaxonApiException;
-import net.sf.saxon.s9api.Serializer;
-import net.sf.saxon.s9api.XPathCompiler;
-import net.sf.saxon.s9api.XPathExecutable;
-import net.sf.saxon.s9api.XPathSelector;
-import net.sf.saxon.s9api.XdmNode;
-import net.sf.saxon.s9api.XdmValue;
-
-import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.core.json.JsonObject;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import net.sf.saxon.s9api.*;
 import org.xml.sax.InputSource;
 
+import javax.xml.transform.Source;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import javax.xml.transform.Source;
-import javax.xml.transform.sax.SAXSource;
-import javax.xml.transform.stream.StreamSource;
 
 /**
  * XML Module<p> Please see the busmods manual for a full description<p>
@@ -109,7 +99,7 @@ public class XmlXPathHandler extends XmlDefaultHandler {
             final Serializer out = processor.newSerializer(writer);
             out.serializeXdmValue(xdmValue);
             JsonObject outputObject = new JsonObject();
-            outputObject.putString("output", writer.toString());
+            outputObject.put("output", writer.toString());
             sendOK(message, outputObject);
         } catch (SaxonApiException | UnsupportedEncodingException | ExecutionException e) {
             sendError(message, e.getMessage());

--- a/src/test/java/org/etourdot/vertx/mods/AbstractXmlTest.java
+++ b/src/test/java/org/etourdot/vertx/mods/AbstractXmlTest.java
@@ -1,0 +1,24 @@
+package org.etourdot.vertx.mods;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import org.junit.Before;
+import org.junit.Rule;
+
+public class AbstractXmlTest {
+
+    @Rule
+    public RunTestOnContext rule = new RunTestOnContext();
+    protected EventBus eventBus;
+
+    @Before
+    public void setup(TestContext context) {
+
+        Vertx vertx = rule.vertx();
+        eventBus = vertx.eventBus();
+
+        vertx.deployVerticle(new XmlWorker(), context.asyncAssertSuccess());
+    }
+}

--- a/src/test/java/org/etourdot/vertx/mods/XmlQueryTest.java
+++ b/src/test/java/org/etourdot/vertx/mods/XmlQueryTest.java
@@ -16,65 +16,39 @@
 
 package org.etourdot.vertx.mods;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.vertx.java.core.AsyncResult;
-import org.vertx.java.core.AsyncResultHandler;
-import org.vertx.java.core.Handler;
-import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.core.json.JsonObject;
-import org.vertx.java.core.logging.Logger;
-import org.vertx.testtools.JavaClassRunner;
-import org.vertx.testtools.TestVerticle;
-
-import static org.vertx.testtools.VertxAssert.assertEquals;
-import static org.vertx.testtools.VertxAssert.assertNotNull;
-import static org.vertx.testtools.VertxAssert.assertTrue;
-import static org.vertx.testtools.VertxAssert.testComplete;
 
 /**
  * XML Module Test<p>
  */
-@RunWith(JavaClassRunner.class)
-public class XmlQueryTest extends TestVerticle {
-
-    private Logger logger;
-
-    @Override
-    public void start() {
-        initialize();
-        final JsonObject conf = new JsonObject();
-        container.deployModule(System.getProperty("vertx.modulename"), conf,
-                new AsyncResultHandler<String>() {
-                    @Override
-                    public void handle(AsyncResult<String> asyncResult) {
-                        if (asyncResult.failed()) {
-                            container.logger().error(asyncResult.cause());
-                        }
-                        assertTrue(asyncResult.succeeded());
-                        assertNotNull("deploymentID should not be null",
-                                asyncResult.result());
-                        // If deployed correctly then start the tests!
-                        startTests();
-                    }
-                });
-        logger = container.logger();
-    }
+@RunWith(VertxUnitRunner.class)
+public class XmlQueryTest extends AbstractXmlTest {
 
     @Test
-    public void testXmlQuery() throws Exception {
-        Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("ok", message.body().getString("status"));
-                assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>true",message.body().getString("output"));
-                testComplete();
-            }
-        };
+    public void testXmlQuery(TestContext context) throws Exception {
+        final Async async = context.async();
+
         final JsonObject jsonObject = new JsonObject();
-        jsonObject.putString(XmlQueryHandler.URL_XML, getClass().getResource(
+        jsonObject.put(XmlQueryHandler.URL_XML, getClass().getResource(
                 "books_standalone_ok.xml").toURI().toASCIIString());
-        jsonObject.putString(XmlQueryHandler.QUERY, "contains(., '352')");
-        vertx.eventBus().send(XmlWorker.QUERY_ADDRESS, jsonObject, replyHandler);
+        jsonObject.put(XmlQueryHandler.QUERY, "contains(., '352')");
+
+        Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess( message -> {
+            context.assertEquals("ok", message.body().getString("status"));
+            context.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>true", message.body().getString("output"));
+            async.complete();
+
+        });
+
+        eventBus.send(XmlWorker.QUERY_ADDRESS, jsonObject, handler);
     }
 
 }

--- a/src/test/java/org/etourdot/vertx/mods/XmlValidationTest.java
+++ b/src/test/java/org/etourdot/vertx/mods/XmlValidationTest.java
@@ -16,181 +16,158 @@
 
 package org.etourdot.vertx.mods;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.vertx.java.core.AsyncResult;
-import org.vertx.java.core.AsyncResultHandler;
-import org.vertx.java.core.Handler;
-import org.vertx.java.core.buffer.Buffer;
-import org.vertx.java.core.eventbus.Message;
-import org.vertx.java.core.json.JsonObject;
-import org.vertx.java.core.logging.Logger;
-import org.vertx.testtools.JavaClassRunner;
-import org.vertx.testtools.TestVerticle;
-
-import static org.vertx.testtools.VertxAssert.assertEquals;
-import static org.vertx.testtools.VertxAssert.assertNotNull;
-import static org.vertx.testtools.VertxAssert.assertNull;
-import static org.vertx.testtools.VertxAssert.assertTrue;
-import static org.vertx.testtools.VertxAssert.testComplete;
 
 /**
  * XML Module Test<p>
  */
-@RunWith(JavaClassRunner.class)
-public class XmlValidationTest extends TestVerticle {
+@RunWith(VertxUnitRunner.class)
+public class XmlValidationTest extends AbstractXmlTest {
 
-    private Logger logger;
-
-    @Override
-    public void start() {
-        initialize();
-        final JsonObject conf = new JsonObject();
-        container.deployModule(System.getProperty("vertx.modulename"), conf,
-                new AsyncResultHandler<String>() {
-                    @Override
-                    public void handle(AsyncResult<String> asyncResult) {
-                        if (asyncResult.failed()) {
-                            container.logger().error(asyncResult.cause());
-                        }
-                        assertTrue(asyncResult.succeeded());
-                        assertNotNull("deploymentID should not be null",
-                                asyncResult.result());
-                        // If deployed correctly then start the tests!
-                        startTests();
-                    }
-                });
-        logger = container.logger();
-    }
-
-    /**
-     * Tests XmlValidationHandler
-     */
 
     @Test
-    public void testXmlValidationWithoutXml() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("error", message.body().getString("status"));
-                assertEquals("xml or xmlurl must be specified", message.body().getString("message"));
-                testComplete();
-            }
-        };
+    public void testXmlValidationWithoutXml(TestContext context) throws Exception {
+
+        Async async = context.async();
+
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+            context.assertEquals("error", message.body().getString("status"));
+            context.assertEquals("xml or xmlurl must be specified", message.body().getString("message"));
+            async.complete();
+        });
+
         final JsonObject jsonObject = new JsonObject();
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, jsonObject, replyHandler);
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, jsonObject, handler);
     }
 
     @Test
-    public void testXmlStreamValidationXmlStandaloneOk() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("ok", message.body().getString("status"));
-                assertNull(message.body().getString("message"));
-                testComplete();
-            }
-        };
+    public void testXmlStreamValidationXmlStandaloneOk(TestContext context) throws Exception {
+        
+        Async async = context.async();
+
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+                context.assertEquals("ok", message.body().getString("status"));
+                context.assertNull(message.body().getString("message"));
+                async.complete();
+        });
         final JsonObject jsonObject = new JsonObject();
-        jsonObject.putString(XmlValidationHandler.XML, "<?xml version='1.0' encoding='UTF-8' standalone='yes'?><root><test>ok</test><okok></okok></root>");
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, jsonObject, replyHandler);
+        jsonObject.put(XmlValidationHandler.XML, "<?xml version='1.0' encoding='UTF-8' standalone='yes'?><root><test>ok</test><okok></okok></root>");
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, jsonObject, handler);
     }
 
     @Test
-    public void testXmlBufferValidationXmlStandaloneOk() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("ok", message.body().getString("status"));
-                assertNull(message.body().getString("message"));
-                testComplete();
-            }
-        };
-        final Buffer buffer = new Buffer();
+    public void testXmlBufferValidationXmlStandaloneOk(TestContext context) throws Exception {
+        
+        Async async = context.async();
+        
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+                context.assertEquals("ok", message.body().getString("status"));
+                context.assertNull(message.body().getString("message"));
+                async.complete();
+        });
+        final Buffer buffer = Buffer.buffer();
         buffer.appendString("<?xml version='1.0' encoding='UTF-8' standalone='yes'?><root><test>ok</test><okok></okok></root>");
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, buffer,replyHandler);
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, buffer,handler);
     }
 
     @Test
-    public void testXmlUrlValidationXmlStandaloneOk() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("ok", message.body().getString("status"));
-                assertNull(message.body().getString("message"));
-                testComplete();
-            }
-        };
+    public void testXmlUrlValidationXmlStandaloneOk(TestContext context) throws Exception {
+
+        Async async = context.async();
+        
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+                context.assertEquals("ok", message.body().getString("status"));
+                context.assertNull(message.body().getString("message"));
+                async.complete();
+        });
         final JsonObject jsonObject = new JsonObject();
-        jsonObject.putString(XmlValidationHandler.URL_XML, getClass().getResource("books_standalone_ok.xml").toURI()
+        jsonObject.put(XmlValidationHandler.URL_XML, getClass().getResource("books_standalone_ok.xml").toURI()
                 .toASCIIString());
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, jsonObject, replyHandler);
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, jsonObject, handler);
     }
 
     @Test
-    public void testXmlValidationXmlPublicDTDOk() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("ok", message.body().getString("status"));
-                assertNull(message.body().getString("message"));
-                testComplete();
-            }
-        };
+    public void testXmlValidationXmlPublicDTDOk(TestContext context) throws Exception {
+
+        Async async = context.async();
+        
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+                context.assertEquals("ok", message.body().getString("status"));
+                context.assertNull(message.body().getString("message"));
+                async.complete();
+        });
         final JsonObject jsonObject = new JsonObject();
-        jsonObject.putString(XmlValidationHandler.URL_XML, getClass().getResource("books_dtd_ok.xml").toURI().toASCIIString());
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, jsonObject, replyHandler);
+        jsonObject.put(XmlValidationHandler.URL_XML, getClass().getResource("books_dtd_ok.xml").toURI().toASCIIString());
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, jsonObject, handler);
     }
 
     @Test
-    public void testXmlValidationXmlPublicDTDKo() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("error", message.body().getString("status"));
-                assertNotNull(message.body().getString("message"));
-                testComplete();
-            }
-        };
+    public void testXmlValidationXmlPublicDTDKo(TestContext context) throws Exception {
+
+        Async async = context.async();
+        
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+            context.assertEquals("error", message.body().getString("status"));
+            context.assertNotNull(message.body().getString("message"));
+            async.complete();
+        });
         final JsonObject jsonObject = new JsonObject();
-        jsonObject.putString(XmlValidationHandler.URL_XML, getClass().getResource("books_dtd_ko.xml").toURI().toASCIIString());
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, jsonObject, replyHandler);
+        jsonObject.put(XmlValidationHandler.URL_XML, getClass().getResource("books_dtd_ko.xml").toURI().toASCIIString());
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, jsonObject, handler);
     }
 
     @Test
-    public void testXmlStreamValidationXmlStandaloneKo() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("error", message.body().getString("status"));
-                assertNotNull(message.body().getString("message"));
-                testComplete();
-            }
-        };
+    public void testXmlStreamValidationXmlStandaloneKo(TestContext context) throws Exception {
+
+        Async async = context.async();
+        
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+            context.assertEquals("error", message.body().getString("status"));
+            context.assertNotNull(message.body().getString("message"));
+            async.complete();
+        });
         final JsonObject jsonObject = new JsonObject();
-        jsonObject.putString(XmlValidationHandler.XML, "<root><test>ok<okok/></root></test>");
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, jsonObject, replyHandler);
+        jsonObject.put(XmlValidationHandler.XML, "<root><test>ok<okok/></root></test>");
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, jsonObject, handler);
     }
 
     @Test
-    public void testXmlBufferValidationXmlStandaloneKo() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("error", message.body().getString("status"));
-                assertNotNull(message.body().getString("message"));
-                testComplete();
-            }
-        };
-        final Buffer buffer = new Buffer();
+    public void testXmlBufferValidationXmlStandaloneKo(TestContext context) throws Exception {
+
+        Async async = context.async();
+        
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+            context.assertEquals("error", message.body().getString("status"));
+            context.assertNotNull(message.body().getString("message"));
+            async.complete();
+        });
+        final Buffer buffer = Buffer.buffer();
         buffer.appendString("<root><test>ok<okok/></root></test>");
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, buffer, replyHandler);
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, buffer, handler);
     }
 
     @Test
-    public void testXmlUrlValidationXmlStandaloneKo() throws Exception {
-        final Handler<Message<JsonObject>> replyHandler = new Handler<Message<JsonObject>>() {
-            public void handle(Message<JsonObject> message) {
-                assertEquals("error", message.body().getString("status"));
-                assertNotNull(message.body().getString("message"));
-                testComplete();
-            }
-        };
+    public void testXmlUrlValidationXmlStandaloneKo(TestContext context) throws Exception {
+
+        Async async = context.async();
+        
+        final Handler<AsyncResult<Message<JsonObject>>> handler = context.asyncAssertSuccess(message -> {
+            context.assertEquals("error", message.body().getString("status"));
+            context.assertNotNull(message.body().getString("message"));
+            async.complete();
+        });
         final JsonObject jsonObject = new JsonObject();
-        jsonObject.putString(XmlValidationHandler.URL_XML, this.getClass().getResource("books_standalone_ko.xml").toURI().toASCIIString());
-        vertx.eventBus().send(XmlWorker.VALIDATION_ADDRESS, jsonObject, replyHandler);
+        jsonObject.put(XmlValidationHandler.URL_XML, this.getClass().getResource("books_standalone_ko.xml").toURI().toASCIIString());
+        eventBus.send(XmlWorker.VALIDATION_ADDRESS, jsonObject, handler);
     }
 }
 


### PR DESCRIPTION
Hi,

I wanted to try your vertx-xml-mod but quickly found out that it worked only for Vertx 2. So I made a quick pass, updated the VertX dependencies and adapted the code to VertX 3

Note that I don't fully understand the VertX mod system, it seems to be connected only to VertX 2 and googling yields very little information. Is it dead?

In any case, all the tests pass and I don't think I altered their logic, so if the code changes look ok to you, feel free to merge it to develop. I guess there might still be some cleanup related to the dependencies, plugins etc.